### PR TITLE
Normative: Remove line-cutting semantics for Atomics.wait

### DIFF
--- a/spec.html
+++ b/spec.html
@@ -134,12 +134,8 @@
     <p>The agent cluster has a store of WaiterList <del>objects</del><ins>Records</ins>; the store is indexed by (_block_, _i_)<ins>, where _block_ is a Shared Data Block and _i_ a byte offset into the memory of _block_</ins>. WaiterLists are agent-independent: a lookup in the store of WaiterLists by (_block_, _i_) will result in the same WaiterList object in any agent in the agent cluster.</p>
     <p>Operations on a WaiterList&mdash;adding and removing waiting agents, traversing the list of agents, suspending and notifying agents on the list, setting and retrieving the Synchronize event&mdash;may only be performed by agents that have entered the WaiterList's critical section.</p>
     <emu-note>
-      <p>Conceptually, agents that call either `Atomics.wait` or `Atomics.waitAsync` are appended to WaiterList. If the call was to `Atomics.wait` in an agent A, a Waiter Record with an *undefined* [[PromiseCapability]] is inserted to be immediately preceding the first element whose [[AgentSignifier]] is A. If the call was to `Atomics.waitAsync`, a WaiterRecord whose [[PromiseCapability]] is the resulting PromiseCapability Record is appended.</p>
-      <p>This enables two design goals:</p>
-      <ol>
-        <li>Waiting agents are notified in FIFO order for fairness.</li>
-        <li>Asynchronous waits in one agent are notified in FIFO order, while synchronous waits are notified before any asynchronous wait. This is because resolving the Promise result of a call to `Atomics.waitAsync` does no meaningful computation if the agent is in a blocking wait.</li>
-      </ol>
+      <p>Conceptually, agents that call either `Atomics.wait` or `Atomics.waitAsync` are appended to WaiterList. For calls to `Atomics.waitAsync`, the appended Waiter Record's [[PromiseCapability]] field contains the Promise returned by the call. For calls to `Atomics.wait`, the appended Waiter Record's [[PromiseCapability]] field is *null*.</p>
+      <p>Waiting agents are notified in FIFO order for fairness. There is a single FIFO queue shared by both synchronous and asynchronous waiters.</p>
     </emu-note>
     <p>The abstract operation GetWaiterList takes two arguments, a Shared Data Block _block_ and a nonnegative integer _i_. It performs the following steps:</p>
     <emu-alg>
@@ -204,15 +200,9 @@
     <emu-alg>
       1. Assert: The calling agent is in the critical section for _WL_.
       1. <del>Assert: _W_ is not on the list of waiters in any WaiterList.</del>
-      1. <ins>Let _inserted_ be *false*.</ins>
-      1. <ins>If _waiterRecord_.[[PromiseCapability]] is *undefined*, then</ins>
-        1. <ins>Assert: There is no Waiter Record in _WL_.[[Waiters]] whose [[PromiseCapability]] field is *undefined* and [[AgentSignifier]] field is _waiterRecord_.[[AgentSignifier]].</ins>
-        1. <ins>For each element _wr_ in _WL_.[[Waiters]], do</ins>
-          1. <ins>If _wr_.[[AgentSignifier]] is _waiterRecord_.[[AgentSignifier]], then</ins>
-            1. <ins>Insert _waiterRecord_ to immediately precede _wr_ in _WL_.[[Waiters]].</ins>
-            1. <ins>Set _inserted_ to *true*.</ins>
-      1. <ins>If _inserted_ is *false*, then</ins>
-        1. <ins>Append _waiterRecord_ as the last element of _WL_.[[Waiters]]</ins>
+      1. <ins>Assert: There is no Waiter Record in _WL_.[[Waiters]] whose [[PromiseCapability]] field is _waiterRecord_.[[PromiseCapability]] and [[AgentSignifier]] field is _waiterRecord_.[[AgentSignifier]].</ins>
+      1. <del>Add _W_ to the end of the list of waiters in _WL_.</del>
+      1. <ins>Append _waiterRecord_ as the last element of _WL_.[[Waiters]]</ins>
       1. <ins>If _waiterRecord_.[[Timeout]] is finite, then in parallel,</ins>
         1. <ins>Wait _waiterRecord_.[[Timeout]] milliseconds.</ins>
         1. <ins>Perform TriggerTimeout(_WL_, _waiterRecord_).</ins>


### PR DESCRIPTION
The line-cutting semantics was originally motivated by the anomaly that
resolving Atomics.waitAsync Promises does no meaningful work if the
agent is blocked by an Atomics.wait.

However, it's hard to reason about line-cutting semantics because it
undermines the currently simple FIFO fairness model, _and_ it also
doesn't actually solve the problem. The core ergonomics problem is the
futility of resolving Atomics.waitAsync Promises while the agent is
blocked -- regardless of location. The Atomics.wait/wake semantics,
however, is staunchly per-location. Solving the very narrow blocked
agent problem for a particular location is not worth the complexity.

Since this is a change to core semantics, please re-review @kmiller68 @littledan @ljharb